### PR TITLE
DDOS-248: Removing the default subspec

### DIFF
--- a/DDUIKitExtensions.podspec
+++ b/DDUIKitExtensions.podspec
@@ -17,20 +17,15 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/dashdevs/uikitextensions.git', :tag => s.version }
 
   s.ios.deployment_target = '9.0'
-
-  s.source_files = 'UIKitExtensions/*.{h,m,swift}'
+  s.ios.public_header_files = 'UIKitExtensions/*.h'
 
   s.frameworks = 'UIKit'
   s.swift_version = '4.2'
 
-  s.default_subspec = 'Core'
-
-  s.subspec 'Core' do |ss|
-      ss.source_files = 'UIKitExtensions/*.{h,m,swift}'
-  end
+  s.default_subspec = :none
 
   s.subspec 'CGSize' do |ss|
-      ss.source_files = 'UIKitExtensions/CGSize+DDExtensions.{swift}'
+    ss.source_files = 'UIKitExtensions/CGSize+DDExtensions.{swift}'
   end
 
   s.subspec 'UIColor' do |ss|
@@ -58,11 +53,11 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'UITextField' do |ss|
-      ss.source_files = 'UIKitExtensions/UITextField+DDExtensions.{h,m}'
+    ss.source_files = 'UIKitExtensions/UITextField+DDExtensions.{h,m}'
   end
 
   s.subspec 'UIApplication' do |ss|
-      ss.source_files = 'UIKitExtensions/UIApplication+DDExtensions.{h,m}'
+    ss.source_files = 'UIKitExtensions/UIApplication+DDExtensions.{h,m}'
   end
 
   s.subspec 'UIKit+Sketch' do |ss|

--- a/README.md
+++ b/README.md
@@ -12,7 +12,24 @@ UIKitExtensions is available through [CocoaPods](https://cocoapods.org). To inst
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'DDUIKitExtensions'
+pod 'DDUIKitExtensions/{ExtensionName}'
+```
+where the {ExtensionName} is a name of extension you need to use. E.g. 'UIImage' for accessing image resizing method.
+
+You can pick one or multiple of the following extensions:
+
+```ruby
+pod 'DDUIKitExtensions/CGSize'
+pod 'DDUIKitExtensions/UIColor'
+pod 'DDUIKitExtensions/UIImage'
+pod 'DDUIKitExtensions/UINavigationController'
+pod 'DDUIKitExtensions/UITableView'
+pod 'DDUIKitExtensions/UIView'
+pod 'DDUIKitExtensions/UIViewController'
+pod 'DDUIKitExtensions/UITextField'
+pod 'DDUIKitExtensions/UIApplication'
+pod 'DDUIKitExtensions/UIKit+Sketch'
+pod 'DDUIKitExtensions/PaddedLabel'
 ```
 
 ## Author


### PR DESCRIPTION
## Task link:

https://itomych.atlassian.net/browse/DDOS-248

## What's changes?

Removing the default subspec to prevent installing all the extensions implicitly.